### PR TITLE
Mark all external links

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -21,7 +21,7 @@
             <li><a href="docs.html">Docs</a></li>
             <li><a href="download.html">Download</a></li>
             <li><a href="contribute.html">Contribute</a></li>
-            <li><a href="https://wiki.ledger-cli.org/">Wiki<sup>◹</sup></a></li>
+            <li><a href="https://wiki.ledger-cli.org/">Wiki</a></li>
           </ul>
         </nav>
       </header>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -26,6 +26,13 @@ header {
    a { text-decoration:none; }
 }
 
+a[href^="https://"]:not(:has(img, svg))::after {
+  content: "\25f9";
+  font-variant-position: super;
+  vertical-align: super;
+  font-size: 80%;
+}
+
 :link {
   color:var(--link-color);
 }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -27,7 +27,9 @@ header {
 }
 
 a[href^="https://"]:not(:has(img, svg))::after {
-  content: "\25f9";
+  content: "\21f1";
+  transform: scaleX(-1);
+  display: inline-block;
   font-variant-position: super;
   vertical-align: super;
   font-size: 80%;


### PR DESCRIPTION
with Upper Right Triangle Unicode Character (U+25F9) (see example screenshot below).

ℹ️ Links containing an `img` or `svg` tag are excluded as the external link indicator would visually disrupt the graphic.

![image](https://user-images.githubusercontent.com/16507/228053114-0c2b088b-d313-4777-abfa-fbb37834d7e1.png)
