### PR TITLE
Add Ledger API documentation

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -32,6 +32,8 @@ jobs:
           cp result/share/doc/ledger/ledger* build/doc
           nix build .#doc-ledger-mode
           cp result/ledger-mode.* build/doc
+          nix build .#doc-ledger-api
+          cp -R result/share/doc/ledger/html build/doc/api/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 $(TEXINFO) $(MANPAGE):
 	$(CURL) --remote-name $(HOST)/$($(@)_repopath)/$@
 
-# TODO: Remove the line after this comment once the next release after 3.3.1
+# TODO: Remove the line after this comment once the next release after 3.3.2
 # is published as it will include the necessary changes for version.texi and
 # related files to be fetched from the tag instead of the master branch.
 version.texi: LATEST := master

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,32 @@
 {
   "nodes": {
-    "flake-utils": {
+    "doxygen-awesome": {
+      "flake": false,
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1676476589,
+        "narHash": "sha256-hcZiHrlgeBLvEhzJk0iZ2GpSxVPn/mjt2Hkt6Mh00OU=",
+        "owner": "jothepro",
+        "repo": "doxygen-awesome-css",
+        "rev": "a7f7891706c656903326f79baf74beb2b711688d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jothepro",
+        "ref": "v2.2.0",
+        "repo": "doxygen-awesome-css",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681037374,
+        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
         "type": "github"
       },
       "original": {
@@ -20,16 +40,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1680162671,
-        "narHash": "sha256-I8ML7sUzsrzRaYCh5b5SFOAFBNGnwzwN1jAyP7ALfKQ=",
-        "owner": "ledger",
+        "lastModified": 1681117469,
+        "narHash": "sha256-GkQbLE/PbPJylmEdSR+As0cNqcT6CUu8gAlM8PSFaNI=",
+        "owner": "afh",
         "repo": "ledger",
-        "rev": "b744ec91707e694c00a53107a516b2bdbee0714e",
+        "rev": "e8aff6f43c99e54a9c6a7d2c7f0ef9c9e96a99e7",
         "type": "github"
       },
       "original": {
-        "owner": "ledger",
-        "ref": "master",
+        "owner": "afh",
+        "ref": "api-documentation",
         "repo": "ledger",
         "type": "github"
       }
@@ -67,11 +87,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1680121753,
-        "narHash": "sha256-rB3ZnNodA4o8Rq0sKZ0t/YdY/MRon4V+bW1b20adgr4=",
+        "lastModified": 1681064623,
+        "narHash": "sha256-UngFykv8KTrjxFeu4ZMvsOwFrxsa0A3ZPwyLhxb0Rrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e779e17ebdf3907ce08c75c7c1b2dc8a1c5038c9",
+        "rev": "da0b0bc6a5d699a8a9ffbf9e1b19e8642307062a",
         "type": "github"
       },
       "original": {
@@ -82,10 +102,26 @@
     },
     "root": {
       "inputs": {
+        "doxygen-awesome": "doxygen-awesome",
         "flake-utils": "flake-utils",
         "ledger": "ledger",
         "ledger-mode": "ledger-mode",
         "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     # NOTA BENE: When a new release of ledger or ledger-mode is available, update
     # the tag in the url below and run `nix flake update`, so that GitHub Actions
     # will build the documentation from the latest ledger and ledger-mode release.
-    # TODO: Replace `master` with the tag of the ledger release following 3.3.1, once available.
+    # TODO: Replace `master` with the tag of the ledger release following 3.3.2, once available.
     ledger.url = "github:ledger/ledger/master";
     ledger-mode.url = "github:ledger/ledger-mode/v4.0.0";
     ledger-mode.flake = false;
@@ -20,7 +20,7 @@
     let
       pkgs = import nixpkgs { inherit system; };
       gems = with pkgs; bundlerEnv {
-        name = "ledger.github.io-gems";
+        name = "ledger-website-gems";
         inherit ruby;
         gemdir = ./.;
       };
@@ -32,7 +32,7 @@
       packages = rec {
         default = website;
         website = pkgs.stdenvNoCC.mkDerivation rec {
-          name = "ledger.github.io";
+          name = "ledger-website";
           src = self;
 
           dontConfigure = true;
@@ -65,7 +65,7 @@
 
          preConfigure = "cd doc";
 
-         cmakeFlags = [ "-DBUILD_WEB_DOCS:BOOL=ON" "-Wno-dev" ];
+         cmakeFlags = [ "-Wno-dev" "-DBUILD_WEB_DOCS:BOOL=ON" ];
 
          buildFlags = "doc";
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,9 @@
     # the tag in the url below and run `nix flake update`, so that GitHub Actions
     # will build the documentation from the latest ledger and ledger-mode release.
     # TODO: Replace `master` with the tag of the ledger release following 3.3.2, once available.
-    ledger.url = "github:ledger/ledger/master";
+    #ledger.url = "github:ledger/ledger/master";
+    # FIXME: Replace the next line with the one above once appropriate PR has been merged to master.
+    ledger.url = "github:afh/ledger/api-documentation";
     ledger-mode.url = "github:ledger/ledger-mode/v4.0.0";
     ledger-mode.flake = false;
     doxygen-awesome.url = "github:jothepro/doxygen-awesome-css/v2.2.0";

--- a/source/docs.html.md
+++ b/source/docs.html.md
@@ -4,19 +4,14 @@ title: Documentation - Ledger
 
 # Documentation
 
-<style>
-.dim, .dim a:link, .dim a:visited { color:#ccc; }
-</style>
-
-* <b><a href="doc/ledger3.html">Ledger 3 manual</a></b> and <a href="doc/ledger3.pdf">pdf</a> <span class="dim">(<a href="https://git.ledger-cli.org/ledger/commits/master/doc/ledger3.texi">changes</a>)
-* <a href="doc/ledger.1.html">Ledger 3 man page</a> and <a href="doc/ledger.1.pdf">pdf</a> <span class="dim">(<a href="https://git.ledger-cli.org/ledger/commits/master/doc/ledger.1">changes</a>)
-* <a href="doc/ledger-mode.html">ledger-mode manual</a> and <a href="doc/ledger-mode.pdf">pdf</a> <span class="dim">(<a href="https://git.ledger-cli.org/ledger-mode/commits/master/doc/ledger-mode.texi">changes</a>)
+* [**Ledger 3 manual**](doc/ledger3.html) and [pdf](doc/ledger3.pdf) ([changes](https://git.ledger-cli.org/ledger/commits/master/doc/ledger3.texi))
+* [Ledger 3 man page](doc/ledger.1.html) and [pdf](doc/ledger.1.pdf) ([changes](https://git.ledger-cli.org/ledger/commits/master/doc/ledger.1))
+* [ledger-mode manual](doc/ledger-mode.html) and [pdf](doc/ledger-mode.pdf) ([changes](https://git.ledger-cli.org/ledger-mode/commits/master/doc/ledger-mode.texi))
 
 ## External links
 
-* The [ledger wiki](https://wiki.ledger-cli.org)
- <span class=dim> ([changes](https://wiki.ledger-cli.org/_history)) </span>
+* The [ledger wiki](https://wiki.ledger-cli.org) ([changes](https://wiki.ledger-cli.org/_history))
 * [ledger on Wikipedia](https://en.wikipedia.org/wiki/Ledger_%28software%29)
- <span class=dim> ([changes](https://en.wikipedia.org/w/index.php?title=Ledger_%28software%29&action=history)) </span>
+ ([changes](https://en.wikipedia.org/w/index.php?title=Ledger_%28software%29&action=history))
 * John gave a nice audio introduction to Ledger in the [2011/01/26 FLOSS Weekly show](https://twit.tv/floss150)
 * hledger.org's [Accounting links](https://hledger.org/accounting.html#accounting-links) has some useful Ledger and accounting links

--- a/source/docs.html.md
+++ b/source/docs.html.md
@@ -6,6 +6,7 @@ title: Documentation - Ledger
 
 * [**Ledger 3 manual**](doc/ledger3.html) and [pdf](doc/ledger3.pdf) ([changes](https://git.ledger-cli.org/ledger/commits/master/doc/ledger3.texi))
 * [Ledger 3 man page](doc/ledger.1.html) and [pdf](doc/ledger.1.pdf) ([changes](https://git.ledger-cli.org/ledger/commits/master/doc/ledger.1))
+* [Ledger 3 API documentation](doc/api)
 * [ledger-mode manual](doc/ledger-mode.html) and [pdf](doc/ledger-mode.pdf) ([changes](https://git.ledger-cli.org/ledger-mode/commits/master/doc/ledger-mode.texi))
 
 ## External links

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -43,6 +43,12 @@ a[href^="https://"]:not(:has(img, svg))::after {
   color:var(--visited-color);
 }
 
+// Change color of links pointing to changes
+a[href^="https://git.ledger-cli.org"][href*="commits/master"],
+a[href*="action=history"],
+a[href="https://wiki.ledger-cli.org/_history"]
+{ color: #ccc; }
+
 nav {
     display:inline;
 


### PR DESCRIPTION
This PR generates Ledger's API documentation and publishes it on ledger-cli.org.

The default styling of doxygen can feel outdated; [jothepro/doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css) strives to remedy that, hence it is included in this project's Nix flake to style the HTML output of Ledger's API documentation.

**NOTA BENE:** This PR depends on [`ledger/ledger#2228`](https://github.com/ledger/ledger/pull/2228) to have been merged.