### PR TITLE
Improve background color of code examples of manual

### DIFF
--- a/custom_theme/sass/darkmode.scss
+++ b/custom_theme/sass/darkmode.scss
@@ -43,6 +43,11 @@
   }
 }
 
+pre.example-preformatted {
+  /* Override hard-coded background color from gnu manual.css with dark/light mode variant */
+  background-color:var(--highlight-code-background-color) !important;
+}
+
 body.light-theme, body.dark-theme {
   color:var(--toggled-color);
   background:var(--toggled-background-color);


### PR DESCRIPTION
The css for manuals loaded from gnu.org hard-codes the background color for code examples, making these illegible in dark-mode.