### PR TITLE
fix: Removing extra 'r' from GitHub release URL

### DIFF
--- a/source/download.md
+++ b/source/download.md
@@ -8,7 +8,7 @@ The [ledger source code](https://git.ledger-cli.org/ledger) is available on GitH
 [![Build Status master](https://img.shields.io/github/actions/workflow/status/ledger/ledger/cmake.yml?branch=master&label=master&style=flat)](https://git.ledger-cli.org/ledger/actions/workflows/cmake.yml)
 [![Status](https://img.shields.io/badge/status-active-brightgreen.svg?style=flat)](https://git.ledger-cli.org/ledger/pulse/monthly)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg?style=flat)](https://opensource.org/licenses/BSD-3-Clause)
-[![GitHub release](https://img.shields.io/github/release/ledger/ledger.svg?style=flat)](https://git.ledger-cli.orgr/ledger/releases)
+[![GitHub release](https://img.shields.io/github/release/ledger/ledger.svg?style=flat)](https://git.ledger-cli.org/ledger/releases)
 
 Several people in the Open Source community have spent time creating
 Ledger binaries for specific platforms. If you discover others or would


### PR DESCRIPTION
I noticed that the GitHub release link didn't resolve because of the TLD being
`orgr` and not `org`.
